### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/src/files/files.controller.ts
+++ b/src/files/files.controller.ts
@@ -15,7 +15,9 @@ import { diskStorage } from 'multer';
 import { Response } from 'express';
 import { ConfigService } from '@nestjs/config';
 import { ApiTags } from '@nestjs/swagger';
+import * as path from 'path';
 
+const PRODUCT_IMAGES_ROOT = path.resolve('./static/products');
 @ApiTags('files')
 @Controller('files')
 export class FilesController {
@@ -29,8 +31,12 @@ export class FilesController {
     @Param('imageName') imageName: string,
     @Res() res: Response,
   ) {
-    const path = this.filesService.getStaticProductImage(imageName);
-    res.sendFile(path);
+    const imagePath = path.resolve(PRODUCT_IMAGES_ROOT, imageName);
+    if (!imagePath.startsWith(PRODUCT_IMAGES_ROOT)) {
+      res.status(403).send('Forbidden');
+      return;
+    }
+    res.sendFile(imagePath);
   }
 
   @Post('product')


### PR DESCRIPTION
Fixes [https://github.com/Juan-Camilo-Sanchez-Echeverri/teslo-shop/security/code-scanning/1](https://github.com/Juan-Camilo-Sanchez-Echeverri/teslo-shop/security/code-scanning/1)

To fix the problem, we need to ensure that the `imageName` parameter is validated and sanitized before being used to construct a file path. We can achieve this by normalizing the path using `path.resolve` and ensuring that the resulting path is within a designated safe directory. This will prevent directory traversal attacks.

1. Import the `path` module.
2. Define a constant for the root directory where product images are stored.
3. Normalize the `imageName` and ensure it is within the root directory.
4. If the normalized path is not within the root directory, return a 403 Forbidden response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
